### PR TITLE
Use group for find count for each status

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -51,8 +51,10 @@ class Task < ActiveRecord::Base
 
   def self.all_counts
     counts = {}
-    @@status_table.each_key{|key|
-      counts[key.to_sym] = self.by_status(key.to_sym).count
+    @@status_table.each_key {|status| counts[status] = 0 }
+
+    self.group(:status).count(:status).each {|status_value, count|
+      counts[@@status_table.key(status_value)] = count
     }
     counts
   end


### PR DESCRIPTION
SQL がいっぱい出ていたのが気になったので、発行回数を減らしました。
今だと、Book 一覧取得時に `Book.count * Task.status_table.count` だけ SQLが発行されているのですが、これを `Book.count` だけにしました。

ぼくの手元のデータ数と、パフォーマンスを添付します。

``` ruby
> Book.count #=> 102
> Task.count #=> 48
```

Before

```
Completed 200 OK in 1292ms (Views: 45.3ms | ActiveRecord: 98.0ms)
```

After

```
Completed 200 OK in 452ms (Views: 18.0ms | ActiveRecord: 34.2ms) 
```
